### PR TITLE
Hammer 2.0 press directive.

### DIFF
--- a/angular-hammer.js
+++ b/angular-hammer.js
@@ -9,6 +9,7 @@
 var hmTouchEvents = angular.module('hmTouchEvents', []),
     hmGestures = ['hmHold:hold',
                   'hmTap:tap',
+                  'hmPress:press',
                   'hmDoubletap:doubletap',
                   'hmDrag:drag',
                   'hmDragstart:dragstart',


### PR DESCRIPTION
With Hammer 2.0 this is needed to catch touches longer than 250ms.
