### PR TITLE
Enable Hammer touch event

### DIFF
--- a/angular-hammer.js
+++ b/angular-hammer.js
@@ -68,6 +68,9 @@ angular.forEach(hmGestures, function(name){
           element.data('hammer', hammer);
         }
 
+        // enable Hammer touch event
+        hammer.get(eventName).set({ enable: true });
+
         // bind Hammer touch event
         hammer.on(eventName, fn);
 


### PR DESCRIPTION
Allows pinch and other gestures to work.

Pinch and rotate are disabled by default. This will enable whatever gestures the developer decides to use.
It isn't explicitly pinch and rotate, because the Hammer guys might add some more gestures that they decide shouldn't be default.

Source:
http://hammerjs.github.io/getting-started/
